### PR TITLE
Implement execution of more instructions + cleanup exec code

### DIFF
--- a/src/instruction/mod.rs
+++ b/src/instruction/mod.rs
@@ -192,8 +192,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             Instruction::Stop => todo!(),
             Instruction::Add => {
                 let stack = mach.stack();
-                let stack_top = stack.peek().unwrap();
-                let stack_top2 = stack.peek_nth(1).unwrap();
+                let [stack_top, stack_top2] = stack.peek_top().unwrap();
 
                 let stack_op_1 = StackOp::Pop;
                 let stack_op_2 = StackOp::Pop;
@@ -216,8 +215,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Mul => {
                 let stack = mach.stack();
-                let mul1 = stack.peek().unwrap();
-                let mul2 = stack.peek_nth(1).unwrap();
+                let [mul1, mul2] = stack.peek_top().unwrap();
                 let product: BitVec<32> = mul1.as_ref().bvmul(mul2.as_ref()).into();
                 let ops = vec![pop(), pop(), push(product)];
                 MachineRecord {
@@ -230,8 +228,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Sub => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let difference: BitVec<32> = a.as_ref().bvsub(b.as_ref()).into();
                 let ops = vec![pop(), pop(), push(difference)];
                 MachineRecord {
@@ -244,8 +241,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Div => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let quot: BitVec<32> = a.as_ref().bvudiv(b.as_ref()).into();
                 let ops = vec![pop(), pop(), push(quot)];
                 MachineRecord {
@@ -258,8 +254,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::SDiv => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let quot: BitVec<32> = a.as_ref().bvsdiv(b.as_ref()).into();
                 let ops = vec![pop(), pop(), push(quot)];
                 MachineRecord {
@@ -272,8 +267,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::SMod => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let rem: BitVec<32> = a.as_ref().bvsmod(b.as_ref()).into();
                 let ops = vec![pop(), pop(), push(rem)];
                 MachineRecord {
@@ -286,8 +280,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Mod => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let rem: BitVec<32> = a.as_ref().bvurem(b.as_ref()).into();
                 let ops = vec![pop(), pop(), push(rem)];
                 MachineRecord {
@@ -300,9 +293,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::AddMod => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
-                let n = stack.peek_nth(2).unwrap();
+                let [a, b, n] = stack.peek_top().unwrap();
                 let res: BitVec<32> = a.as_ref().bvadd(b.as_ref()).bvurem(n.as_ref()).into();
                 let ops = vec![pop(), pop(), pop(), push(res)];
                 MachineRecord {
@@ -315,9 +306,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::MulMod => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
-                let n = stack.peek_nth(2).unwrap();
+                let [a, b, n] = stack.peek_top().unwrap();
                 let res: BitVec<32> = a.as_ref().bvmul(b.as_ref()).bvurem(n.as_ref()).into();
                 let ops = vec![pop(), pop(), pop(), push(res)];
                 MachineRecord {
@@ -330,8 +319,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Exp => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let power = stack.peek_nth(1).unwrap();
+                let [a, power] = stack.peek_top().unwrap();
                 let mut power_conc = power.as_ref().as_u64().unwrap();
                 let mut exp: BitVec<32> = if power_conc == 0 {
                     bvi(1)
@@ -357,8 +345,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Lt => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let lt: BitVec<32> = a
                     .as_ref()
                     .bvult(b.as_ref())
@@ -377,8 +364,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Gt => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let lt: BitVec<32> = a
                     .as_ref()
                     .bvugt(b.as_ref())
@@ -397,8 +383,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Slt => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let lt: BitVec<32> = a
                     .as_ref()
                     .bvslt(b.as_ref())
@@ -417,8 +402,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Sgt => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let gt: BitVec<32> = a
                     .as_ref()
                     .bvsgt(b.as_ref())
@@ -437,8 +421,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Eq => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let eq: BitVec<32> = a
                     .as_ref()
                     ._eq(b.as_ref())
@@ -457,8 +440,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::And => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let and = a.as_ref().bitand(b.as_ref()).into();
 
                 let ops = vec![pop(), pop(), push(and)];
@@ -473,8 +455,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Or => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let or = a.as_ref().bitor(b.as_ref()).into();
 
                 let ops = vec![pop(), pop(), push(or)];
@@ -489,8 +470,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Xor => {
                 let stack = mach.stack();
-                let a = stack.peek().unwrap();
-                let b = stack.peek_nth(1).unwrap();
+                let [a, b] = stack.peek_top().unwrap();
                 let xor = a.as_ref().bitxor(b.as_ref()).into();
 
                 let ops = vec![pop(), pop(), push(xor)];
@@ -522,9 +502,8 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             Instruction::Byte => todo!(),
             Instruction::Shl => {
                 let stack = mach.stack();
-                let shift = stack.peek().unwrap();
-                let value = stack.peek_nth(1).unwrap();
-                
+                let [shift, value] = stack.peek_top().unwrap();
+
                 let shl = value.as_ref().bvshl(shift.as_ref()).into();
 
                 let ops = vec![pop(), pop(), push(shl)];
@@ -539,9 +518,8 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
             }
             Instruction::Shr => {
                 let stack = mach.stack();
-                let shift = stack.peek().unwrap();
-                let value = stack.peek_nth(1).unwrap();
-                
+                let [shift, value] = stack.peek_top().unwrap();
+
                 let shr = value.as_ref().bvlshr(shift.as_ref()).into();
 
                 let ops = vec![pop(), pop(), push(shr)];
@@ -553,7 +531,7 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
                     constraints: None,
                     halt: false,
                 }
-            },
+            }
             Instruction::Sha3 => todo!(),
             Instruction::Address => todo!(),
             Instruction::Balance => {

--- a/src/instruction/mod.rs
+++ b/src/instruction/mod.rs
@@ -173,6 +173,19 @@ pub enum Instruction {
     // Assert(BitVec<32>),
 }
 
+fn exec_dup_nth(mach: &EvmState, n: usize) -> MachineRecord<32> {
+    let item = mach.stack().peek_nth(n - 1).unwrap();
+    let ops = vec![push(item.clone())];
+
+    MachineRecord {
+        stack: Some(StackChange::with_ops(ops)),
+        pc: (mach.pc(), mach.pc() + 1),
+        mem: Default::default(),
+        halt: false,
+        constraints: None,
+    }
+}
+
 impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
     fn exec(&self, mach: &EvmState) -> MachineRecord<32> {
         match self {
@@ -462,9 +475,9 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
                 let stack = mach.stack();
                 let a = stack.peek().unwrap();
                 let b = stack.peek_nth(1).unwrap();
-                let and = a.as_ref().bitor(b.as_ref()).into();
+                let or = a.as_ref().bitor(b.as_ref()).into();
 
-                let ops = vec![pop(), pop(), push(and)];
+                let ops = vec![pop(), pop(), push(or)];
 
                 MachineRecord {
                     stack: Some(StackChange::with_ops(ops)),
@@ -478,9 +491,9 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
                 let stack = mach.stack();
                 let a = stack.peek().unwrap();
                 let b = stack.peek_nth(1).unwrap();
-                let and = a.as_ref().bitxor(b.as_ref()).into();
+                let xor = a.as_ref().bitxor(b.as_ref()).into();
 
-                let ops = vec![pop(), pop(), push(and)];
+                let ops = vec![pop(), pop(), push(xor)];
 
                 MachineRecord {
                     stack: Some(StackChange::with_ops(ops)),
@@ -1299,198 +1312,22 @@ impl<'ctx> MachineInstruction<'ctx, 32> for Instruction {
                     constraints: None,
                 }
             }
-            Instruction::Dup1 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup2 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup3 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup4 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup5 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup6 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup7 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup8 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup9 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup10 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup11 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup12 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup13 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup14 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup15 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
-            Instruction::Dup16 => {
-                let item = mach.stack().peek_nth(1).unwrap();
-                let ops = vec![push(item.clone())];
-
-                MachineRecord {
-                    stack: Some(StackChange::with_ops(ops)),
-                    pc: (mach.pc(), mach.pc() + 1),
-                    mem: Default::default(),
-                    halt: false,
-                    constraints: None,
-                }
-            }
+            Instruction::Dup1 => exec_dup_nth(mach, 1),
+            Instruction::Dup2 => exec_dup_nth(mach, 2),
+            Instruction::Dup3 => exec_dup_nth(mach, 3),
+            Instruction::Dup4 => exec_dup_nth(mach, 4),
+            Instruction::Dup5 => exec_dup_nth(mach, 5),
+            Instruction::Dup6 => exec_dup_nth(mach, 6),
+            Instruction::Dup7 => exec_dup_nth(mach, 7),
+            Instruction::Dup8 => exec_dup_nth(mach, 8),
+            Instruction::Dup9 => exec_dup_nth(mach, 9),
+            Instruction::Dup10 => exec_dup_nth(mach, 10),
+            Instruction::Dup11 => exec_dup_nth(mach, 11),
+            Instruction::Dup12 => exec_dup_nth(mach, 12),
+            Instruction::Dup13 => exec_dup_nth(mach, 13),
+            Instruction::Dup14 => exec_dup_nth(mach, 14),
+            Instruction::Dup15 => exec_dup_nth(mach, 15),
+            Instruction::Dup16 => exec_dup_nth(mach, 16),
             Instruction::Swap1 => todo!(),
             Instruction::Swap2 => todo!(),
             Instruction::Swap3 => todo!(),

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -35,6 +35,9 @@ impl<const SZ: u32> Stack<SZ> {
     }
 
     pub fn peek_nth(&self, n: usize) -> Option<&BitVec<SZ>> {
+        if n >= self.size() {
+            return None;
+        }
         self.stack.get(self.size - n - 1)
     }
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -37,6 +37,14 @@ impl<const SZ: u32> Stack<SZ> {
     pub fn peek_nth(&self, n: usize) -> Option<&BitVec<SZ>> {
         self.stack.get(self.size - n - 1)
     }
+
+    pub fn peek_top<const N: usize>(&self) -> Option<[&BitVec<SZ>; N]> {
+        if self.size() < N {
+            return None;
+        }
+
+        Some(std::array::from_fn(|i| self.peek_nth(i).unwrap()))
+    }
 }
 
 impl<const SZ: u32> MachineComponent for Stack<SZ> {


### PR DESCRIPTION
Sort of a hodgepodge of changes (I can split them out into separate PRs if you want):
- Implement the rest of the arithmetic/bitwise instructions
- Deduplicate the code for exec on `DedupN` instructions
- Cleanup some variable names
- Add a method to `Stack` to peek multiple entries at once, so you can write e.g.
  ```rust
  let [a, b] = stack.peek_top().unwrap();
  ```
  instead of
  ```rust
  let a = stack.peek().unwrap();
  let b = stack.peek_nth(1).unwrap();
  ```
- Check the index in `peek_nth` so we don't overflow when `n >= stack.size`